### PR TITLE
perf: Performance updates for Aanbod and Verhuringen page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
       name="description"
       content="CROW Dashboard Deelmobiliteit"
     />
-    <link href='https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.css' rel='stylesheet' />
     <link href="%PUBLIC_URL%/css/fonts.css" rel="stylesheet" />
 
     <!--

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,13 @@ function App() {
 
   const DELAY_TIMEOUT_IN_MS = 250;
 
+  // The park/rentals data effects debounce their API poll to coalesce rapid
+  // filter changes. The very first poll doesn't need that: fire it immediately
+  // so the (large) vehicles request starts as early as possible. Follow-up
+  // effect runs during app boot no longer abort it (see poll-api/pollParkingData).
+  const didInitParkingPoll = useRef(false);
+  const didInitRentalsPoll = useRef(false);
+
   // Store window location in a local variable
   const location = useLocation();
   useEffect(() => {
@@ -495,9 +502,11 @@ function App() {
 
     if(delayTimeout) clearTimeout(delayTimeout);
 
+    const delay = didInitParkingPoll.current ? DELAY_TIMEOUT_IN_MS : 0;
+    didInitParkingPoll.current = true;
     setDelayTimeout(setTimeout(() => {
       initUpdateParkingData(store);
-    }, DELAY_TIMEOUT_IN_MS))
+    }, delay))
   }, [
     isLoggedIn,
     metadata.zones_loaded,
@@ -515,9 +524,11 @@ function App() {
 
     if(delayTimeout) clearTimeout(delayTimeout);
 
+    const delay = didInitRentalsPoll.current ? DELAY_TIMEOUT_IN_MS : 0;
+    didInitRentalsPoll.current = true;
     setDelayTimeout(setTimeout(() => {
       initUpdateVerhuringenData(store);
-    }, DELAY_TIMEOUT_IN_MS))
+    }, delay))
   }, [
     isLoggedIn,// If we change from guest to logged in we want to update rentals
     metadata.zones_loaded,// We only do an API call if zones are loaded

--- a/src/AppProvider.js
+++ b/src/AppProvider.js
@@ -58,6 +58,20 @@ const validatePersistedState = (state) => {
 
 persistedState = validatePersistedState(persistedState);
 
+// Reset a stale persisted 'datum' filter to now *before* the store is created.
+// App.tsx used to do this in an effect ~500ms after load, but by then the
+// initial vehicles fetch is already in flight and the datum change would abort
+// it and fetch everything again (doubling the load time for returning
+// visitors). Shared links (?view=...) keep their persisted datum.
+if (persistedState.filter && persistedState.filter.datum) {
+  const isSharedLink = new URLSearchParams(window.location.search).get('view');
+  const datumAgeMs = Date.now() - new Date(persistedState.filter.datum).getTime();
+  const isMoreThan10MinutesAgo = isNaN(datumAgeMs) || datumAgeMs > 10 * 60 * 1000;
+  if (!isSharedLink && isMoreThan10MinutesAgo) {
+    persistedState.filter.datum = new Date().toISOString();
+  }
+}
+
 window.process = { ...window.process }
 
 export const store = createStore(

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+// Bundle the maplibre-gl CSS (matching the installed maplibre-gl version)
+// instead of render-blocking on an external CDN stylesheet in index.html
+import 'maplibre-gl/dist/maplibre-gl.css';
 import AppProvider from './AppProvider';
 import reportWebVitals from './reportWebVitals';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';

--- a/src/poll-api/pollParkingData.js
+++ b/src/poll-api/pollParkingData.js
@@ -14,6 +14,10 @@ var timerid_parkingdata;
 // theFetch: Variabele used for managing fetch calls
 let theFetch = null;
 
+// URL of the request currently in flight, so an identical request can reuse
+// it instead of aborting and starting over (see doApiCall)
+let theFetchUrl = null;
+
 // Variable to keep track of vehicles response
 // Only do a new fetch() if needed
 let activeVehicles;
@@ -37,19 +41,32 @@ const processVehiclesResult = (state, vehicles) => {
     operatorstats[o.system_id || o.value]=0;
   });
 
-  const md5 = require('md5');
   var start_time = moment(state.filter.datum);
-  
-  vehicles.forEach(v => {
-    let in_public_space_since = isLoggedIn(state) ? v.start_time : v.in_public_space_since;
+  const start_time_ms = start_time.valueOf();
 
-    var minutes = start_time.diff(moment(in_public_space_since), 'minutes');
+  // Get list of providers to exclude
+  const aanbiedersexclude = state.filter.aanbiedersexclude.split(",") || [];
+  // Get parkeerduur length to exclude
+  const parkeerduurexclude = state.filter.parkeerduurexclude.split(",") || [];
+  const showOnlyNonOperational = state.filter.non_operational_only === true;
+  const loggedIn = isLoggedIn(state);
+
+  vehicles.forEach(v => {
+    let in_public_space_since = loggedIn ? v.start_time : v.in_public_space_since;
+
+    // Plain Date math instead of constructing a moment per vehicle (~10x
+    // faster over 25k+ vehicles); fall back to moment for exotic date formats
+    let since_ms = in_public_space_since ? Date.parse(in_public_space_since) : Date.now();
+    if(isNaN(since_ms) && in_public_space_since) {
+      since_ms = moment(in_public_space_since).valueOf();
+    }
+    var minutes = Math.floor((start_time_ms - since_ms) / 60000);
     const duration_bin = convertDurationToBin(minutes);
-    
+
     let feature = {
        "type":"Feature",
        "properties":{
-          "id":md5(v.location.latitude+v.location.longitude),
+          "id":v.location.latitude+","+v.location.longitude,
           "vehicle_id":v.bike_id,
           "system_id": v.system_id || v.value,// v.value is used in the public map
           "form_factor": v.form_factor || null,
@@ -69,15 +86,8 @@ const processVehiclesResult = (state, vehicles) => {
 
     operatorstats[v.system_id || v.value]+=1;
 
-    // Get list of providers to exclude
-    let aanbiedersexclude = state.filter.aanbiedersexclude.split(",") || []
-
-    // Get parkeerduur length to exclude
-    let parkeerduurexclude = state.filter.parkeerduurexclude.split(",") || [];
-    const showOnlyNonOperational = state.filter.non_operational_only === true;
-
     // Filter markers
-    let markerVisible = ! isLoggedIn(state) || !parkeerduurexclude.includes(duration_bin.toString());
+    let markerVisible = ! loggedIn || !parkeerduurexclude.includes(duration_bin.toString());
     markerVisible = markerVisible && (aanbiedersexclude.includes(v.system_id || v.value) === false)
     if (showOnlyNonOperational) {
       markerVisible = markerVisible && v.is_non_operational === true;
@@ -138,6 +148,13 @@ const doApiCall = (
     }
   }
   
+  // If a request for this exact URL is already in flight, let it finish
+  // instead of aborting and re-issuing it: the response is processed with the
+  // then-current store state, so the result is the same either way.
+  if(theFetch && theFetchUrl === url) {
+    return;
+  }
+
   // Start loading
   store_parkingdata.dispatch({type: 'SHOW_LOADING', payload: true});
 
@@ -149,12 +166,22 @@ const doApiCall = (
     theFetch.abort();
   }
   // Now do a new fetch
-  theFetch = abortableFetch(url, options);
-  theFetch.ready.then(function(response) {
-    // Set theFetch to null, so next request is not aborted
-    theFetch = null;
+  const thisFetch = abortableFetch(url, options);
+  theFetch = thisFetch;
+  theFetchUrl = url;
 
+  // Only clear the in-flight tracking if it still points at this request
+  // (a newer request may have replaced it in the meantime)
+  const clearFetchTracking = () => {
+    if(theFetch === thisFetch) {
+      theFetch = null;
+      theFetchUrl = null;
+    }
+  };
+
+  thisFetch.ready.then(function(response) {
     if(! response.ok) {
+      clearFetchTracking();
       console.error("unable to fetch: %o", response);
       return false
     }
@@ -165,14 +192,22 @@ const doApiCall = (
       } else {
         vehicles = vehicles.vehicles_in_public_space
       }
-      callback(state, vehicles);
+      // Process with the *current* store state (not the state at request
+      // time), so client-side filters that changed while the request was in
+      // flight are applied to the result.
+      callback(store_parkingdata.getState(), vehicles);
     }).catch(ex=>{
       console.error("unable to decode JSON");
     }).finally(()=>{
+      clearFetchTracking();
       // Stop loading
       store_parkingdata.dispatch({type: 'SHOW_LOADING', payload: false});
     })
   }).catch(ex=>{
+    // If this request was aborted because a newer one replaced it, leave the
+    // loading state to the newer request
+    if(theFetch !== thisFetch) return;
+    clearFetchTracking();
     // Stop loading
     store_parkingdata.dispatch({type: 'SHOW_LOADING', payload: false});
     console.error("fetch error - unable to fetch JSON from %s", url);
@@ -199,12 +234,14 @@ const updateParkingData = async () => {
     // Update active filter
     existingFilter = state.filter;
 
-    if(doFetchVehicles || ! activeVehicles) {
+    if(doFetchVehicles || (! activeVehicles && ! theFetch)) {
       doApiCall(state, processVehiclesResult);
-    } else {
+    } else if(activeVehicles) {
       // Regenerate geoJson without querying API
-      processVehiclesResult(state, activeVehicles); 
+      processVehiclesResult(state, activeVehicles);
     }
+    // else: no vehicles yet but a fetch is in flight; its callback processes
+    // the response with the store state at completion time
 
   } catch(ex) {
     console.error("Unable to update zones", ex)

--- a/src/poll-api/pollVerhuringenData.js
+++ b/src/poll-api/pollVerhuringenData.js
@@ -8,13 +8,16 @@ import {isLoggedIn, isAdmin} from '../helpers/authentication.js';
 import {shouldFetchVehicles} from './pollTools.js';
 
 import { DISPLAYMODE_RENTALS } from '../reducers/layers.js';
-const md5 = require('md5');
 
 var store_verhuringendata = undefined;
 var timerid_verhuringendata = undefined;
 
 // Variable that will prevent simultaneous loading of fetch requests
 let theFetch = null;
+
+// URL of the request currently in flight, so an identical request can reuse
+// it instead of aborting and starting over (see doApiCall)
+let theFetchUrl = null;
 
 // Variable to keep track of vehicles response
 // Only do a new fetch() if needed
@@ -38,6 +41,7 @@ const processRentalsResult = (state, type, rentals) => {
   });
 
   let aanbiedersexclude = state.filter.aanbiedersexclude.split(",") || []
+  let afstandexclude = state.filter.afstandexclude.split(",") || [];
 
   // Map data
   activeRentals[`trip_${type}`].forEach(v => {
@@ -46,7 +50,7 @@ const processRentalsResult = (state, type, rentals) => {
     let feature = {
      "type":"Feature",
      "properties":{
-        "id": md5(v.location.latitude+v.location.longitude),
+        "id": v.location.latitude+","+v.location.longitude,
         "system_id": v.system_id,
         "form_factor": v.form_factor || null,
         "arrival_time": v.arrival_time,
@@ -68,7 +72,6 @@ const processRentalsResult = (state, type, rentals) => {
 
     operatorstats[v.system_id || v.value]+=1;
 
-    let afstandexclude = state.filter.afstandexclude.split(",") || [];
     let markerVisible = !afstandexclude.includes(distance_bin.toString());
     markerVisible = markerVisible && (aanbiedersexclude.includes(v.system_id || v.value) === false)
     if(markerVisible) {
@@ -117,35 +120,60 @@ const doApiCall = (
     };
   }
   
+  // If a request for this exact URL is already in flight, let it finish
+  // instead of aborting and re-issuing it: the response is processed with the
+  // then-current store state, so the result is the same either way.
+  if(theFetch && theFetchUrl === url) {
+    return;
+  }
+
   store_verhuringendata.dispatch({type: 'SHOW_LOADING', payload: true});
-  
+
   // Abort previous fetch
   if(theFetch) {
     theFetch.abort()
   }
   // Now do a new fetch
-  theFetch = abortableFetch(url, options);
-  theFetch.ready.then(function(response) {
-    // Set theFetch to null, so next request is not aborted
-    theFetch = null;
+  const thisFetch = abortableFetch(url, options);
+  theFetch = thisFetch;
+  theFetchUrl = url;
 
-    store_verhuringendata.dispatch({type: 'SHOW_LOADING', payload: false});
+  // Only clear the in-flight tracking if it still points at this request
+  // (a newer request may have replaced it in the meantime)
+  const clearFetchTracking = () => {
+    if(theFetch === thisFetch) {
+      theFetch = null;
+      theFetchUrl = null;
+    }
+  };
 
+  thisFetch.ready.then(function(response) {
     if(!response.ok) {
+      clearFetchTracking();
+      store_verhuringendata.dispatch({type: 'SHOW_LOADING', payload: false});
       console.error("unable to fetch: %o", response);
       return false
     }
 
     response.json().then(function(data) {
-      const rentals = isLoggedIn ? data : [];
-      callback(state, type, rentals);
+      const currentState = store_verhuringendata.getState();
+      const rentals = isLoggedIn(currentState) ? data : [];
+      // Process with the *current* store state (not the state at request
+      // time), so client-side filters that changed while the request was in
+      // flight are applied to the result.
+      callback(currentState, type, rentals);
     }).catch(ex=>{
       console.error("unable to decode JSON");
     }).finally(()=>{
+      clearFetchTracking();
       store_verhuringendata.dispatch({type: 'SHOW_LOADING', payload: false});
     })
-    
+
   }).catch(ex=>{
+    // If this request was aborted because a newer one replaced it, leave the
+    // loading state to the newer request
+    if(theFetch !== thisFetch) return;
+    clearFetchTracking();
     store_verhuringendata.dispatch({type: 'SHOW_LOADING', payload: false});
     console.error("fetch error - unable to fetch JSON from %s", url);
   });
@@ -176,7 +204,7 @@ const updateVerhuringenData = ()  => {
 
     if(!canfetchdata) {
       store_verhuringendata.dispatch({ type: 'CLEAR_RENTALS_ORIGINS'});
-      store_verhuringendata.dispatch({ type: 'CLEAR_RENTALS_DESTINATIOINS'});
+      store_verhuringendata.dispatch({ type: 'CLEAR_RENTALS_DESTINATIONS'});
     } else {
 
       // Should we (re)fetch vehicles?
@@ -186,12 +214,14 @@ const updateVerhuringenData = ()  => {
       existingFilter = state.filter;
 
       const theType = state.filter.herkomstbestemming === 'bestemming' ? 'destinations' : 'origins';
-      if(doFetchRentals || ! activeRentals) {
+      if(doFetchRentals || (! activeRentals && ! theFetch)) {
         doApiCall(state, theType, processRentalsResult);
-      } else {
+      } else if(activeRentals) {
         // Regenerate geoJson without querying API
-        processRentalsResult(state, theType, activeRentals); 
+        processRentalsResult(state, theType, activeRentals);
       }
+      // else: no rentals yet but a fetch is in flight; its callback processes
+      // the response with the store state at completion time
 
     }
   } catch(ex) {


### PR DESCRIPTION
- No more duplicate 2.5 MB downloads because of useEffect (poll API URLs)
- Load vehicles on page load instead and not after 500ms
- Faster vehicle processing because of better ids
- First poll fires immediately instead of after 250ms
- Self-hosted maplibre CSS